### PR TITLE
added custom event to enable or disable wall slide

### DIFF
--- a/plugins/PlatformerPlus/events/eventPPSetWallSlide.js
+++ b/plugins/PlatformerPlus/events/eventPPSetWallSlide.js
@@ -1,0 +1,42 @@
+const id = "PM_EVENT_TOGGLE_WALL_SLIDE";
+const groups = ["Platformer+"];
+const name = "Toggle Wall Slide";
+
+const fields = [
+  {
+    key: "wallSlideEnabled",
+    label: "Enable or Disable Wall Slide",
+    type: "select",
+    defaultValue: "0",
+    options: [
+      ["0", "Disable Wall Slide"],
+      ["1", "Enable Wall Slide"],
+    ],
+  },
+  {
+    key: "field",
+    defaultValue: "plat_wall_slide",
+  },
+];
+
+const compile = (input, helpers) => {
+  const {
+    _addComment,
+    _addNL,
+    _setConstMemInt16,
+    _setMemInt16ToVariable,
+  } = helpers;
+  _addComment("Toggle Wall Slide");
+  _setConstMemInt16(input.field, input.wallSlideEnabled);
+
+  _addNL();
+};
+
+module.exports = {
+  id,
+  name,
+  groups,
+  fields,
+  compile,
+  allowedBeforeInitFade: true,
+};


### PR DESCRIPTION
I couldn't find the option to enable or disable wall slide from a custom event. 
For my game, I want to only have this enabled for certain walls, so a trigger field before that wall can be placed and I activate wall slide by entering the trigger field and disable it by leaving the trigger field.

So this new custom event provides a trigger to enable or disable wall slide.