### PR TITLE
Added a pixel threshold for snapping to a platform while jumping through

### DIFF
--- a/plugins/PlatformerPlus/engine/engine.json
+++ b/plugins/PlatformerPlus/engine/engine.json
@@ -358,6 +358,16 @@
       "defaultValue": 4,
       "min": 0,
       "max": 32
+    },
+    {
+      "key": "plat_jump_through_snap_threshold",
+      "label": "Jump Through Platforms Snap Threshold (pixels)",
+      "group": "Platformer Plus",
+      "type": "slider",
+      "cType": "UBYTE",
+      "defaultValue": 2,
+      "min": 0,
+      "max": 8
     }
   ]
 }

--- a/plugins/PlatformerPlus/engine/include/states/platform.h
+++ b/plugins/PlatformerPlus/engine/include/states/platform.h
@@ -62,5 +62,6 @@ extern UBYTE plat_dash_through;
 extern WORD plat_dash_dist;       
 extern UBYTE plat_dash_frames;
 extern UBYTE plat_dash_ready_max; 
+extern UBYTE plat_jump_through_snap_threshold; 
 
 #endif


### PR DESCRIPTION
When jumping through a 1-way platform from the bottom, the collision code will "snap" the player to be on top of the platform if the collision happens while the player is inside the tile (8 pixels high). With this change, you can control the pixel overlap before the player will snap up to land on the platform.